### PR TITLE
Fixed Category "SurpassingGoogle", Issue #188, Other Minor Fix

### DIFF
--- a/src/assets/steemgigs.scss
+++ b/src/assets/steemgigs.scss
@@ -27,7 +27,7 @@ body {
 .el-main {
   padding: 30px 90px;
   overflow: auto;
-  height: calc(100vh - 105px);
+  height: calc(100vh - 130px);
 }
 
 h1, h2, h4, h5 {

--- a/src/components/profile/profile-extras.vue
+++ b/src/components/profile/profile-extras.vue
@@ -21,7 +21,8 @@
            <h5 class="card-title">I made this</h5>
            <p>{{ profile.portfolio.description || 'Not Available' }}</p>
            <h5 class="card-title">Portfolio URL</h5>
-           <p>{{ profile.portfolio.url || 'Not Available' }}</p>
+            <p class="not-avail" v-if='profile.portfolio.url.length === 0'>Not Available</p>
+            <a target='_blank' v-bind:href="profile.portfolio.url" v-html="profile.portfolio.url"></a>
             <h5 class="card-title">Links</h5>
             <p class="social-link" v-for="(social, key, index) in profile.social" :key="index">
                <span class="site-label">{{ key }}: </span><span class="site-link" v-html="(social.match(/^(http|https):/)) ? `<a target='_blank' href='${social}'>${social}</a>` : social || ' Link not provided'"/>

--- a/src/pages/platform/category.vue
+++ b/src/pages/platform/category.vue
@@ -17,7 +17,7 @@
       <!-- Posts -->
        <el-col  :xs="24" :sm="24" :md="24" :lg="18" :xl="18">
        <el-row :gutter="15">
-            <categoryPreview mode="pages" :category="category" post_type="steemgigs_post" :limit="8" :header="categoryDetails.name" :description="categoryDetails.description"></categoryPreview>
+            <categoryPreview mode="pages" :category="category" :post_type="categoryDetails.type" :limit="8" :header="categoryDetails.name" :description="categoryDetails.description"></categoryPreview>
         </el-row>
         </el-col>
     </el-main>
@@ -46,6 +46,13 @@ export default {
       let details = {}
       this.categories.forEach((category, index) => {
         if (this.slugify(category.name) === pageCategory) {
+          switch (category.name) {
+            case 'SurpassingGoogle':
+            details.type = "steemgigs_surpassinggoogle"
+            break
+            default:
+            details.type = "steemgigs_post"
+          }
           details.name = this.capitalize(category.name)
           details.description = category.description
           details.subcategories = category.subcategories


### PR DESCRIPTION
# Major Fix & Update:
This Pull Request Solves Issue #188

#### More Details of Issue:
### Reason:
`<categoryPreview>` Tag was Static for only Showing Gigs from Type `steemgigs_posts`. SurpassingGoogle Category makes Post in `steemgigs_surpassinggoogle`. due to this Reason Gigs/Posts was not being Loaded.

### Solution:
Solved by adding a Dynamic Attribute is `<categoryPreview>` Tag, which allows it to get `post_type` attribute Value from `details.type` variable. `details.type` Variable is assigned to `steemgigs_surpassinggoogle` Only when Category Name is SurpassingGoogle, due to a Switch Statement.

### Before:
![pic2](https://user-images.githubusercontent.com/34513931/57980526-32cb6280-7a46-11e9-94c2-c3cc5047af7a.png)
### After:
![pic3](https://user-images.githubusercontent.com/34513931/57980532-3b239d80-7a46-11e9-9558-69d37ecc008c.png)

# Other Fix & Updates:
### Portfolio URL Fix:
Portfolio on Profile Extras is shown as Plain text which is not Expected Behavior. This is a Fix to it. It was also Overflowing from the side bar. Solved
### Before & After:
![pic4](https://user-images.githubusercontent.com/34513931/57980607-f77d6380-7a46-11e9-9829-0b747e78f125.png)

### Body Crop Fix:
Reduced Class `.el-main` height which is the main app body of any page. It's height was large and mostly last buttons were being Cropped into to screen on all Pages (Better Visible on Profile Page On last Button "Get Certified").. Reduced the Height with `25px`. The issue is solved now
### Before & After:
![pic7](https://user-images.githubusercontent.com/34513931/57981620-226db480-7a53-11e9-9639-e9023d5d3aea.png)

[Patch](https://github.com/steemgigs/steemgigs/pull/189.patch), [Diff](https://github.com/steemgigs/steemgigs/pull/189.diff)