### PR TITLE
Add follow modal after user logs into prompt to follow SteemGigs (task: #64)

### DIFF
--- a/src/components/layout/nav.vue
+++ b/src/components/layout/nav.vue
@@ -84,7 +84,7 @@
                   <router-link class="waves-effect" :to="'/@' + $store.state.username"> {{ $store.state.username + ' (' + repp + ') ' }} </router-link>
                 </el-dropdown-item>
                 <el-dropdown-item>
-                  <a class="waves-effect" @click.prevent="follow()">Follow SteemGigs <i class="icon ion-star follow-icon"></i><!-- star-outline icon when off --></a>
+                  <a class="waves-effect" v-if="!$store.state.profile.follower" @click.prevent="followSteemgigs()">Follow SteemGigs</a>
                 </el-dropdown-item>
                 <el-dropdown-item>
                   <router-link class="waves-effect" to="/bropro">BroPro</router-link>
@@ -130,6 +130,8 @@
 import M from 'materialize-css'
 import modal from '@/mixins/modal.js'
 import search from '@/mixins/search.js'
+import sc2 from '@/services/sc2'
+import steem from 'steem';
 
 export default {
   mixins: [modal, search],
@@ -167,14 +169,30 @@ export default {
       }
     }
   },
+  methods: {
+    followSteemgigs () {
+      sc2.setAccessToken(this.$store.state.accessToken)
+      sc2.follow(this.$store.state.username, 'steemgigs', function (err, res) {
+        this.$store.commit('setFollower', true)
+      }.bind(this))
+    }
+  },
   mounted () {
     this.$eventBus.$on('profile-fetched', () => {
       this.profile = this.$store.state.profile
     })
+
     let elem = document.querySelector('.modal')
     M.Modal.init(elem, {
       dismissible: true
     })
+
+    const username = this.$store.state.username;
+    steem.api.setOptions({ url: 'https://api.steemit.com'});
+    steem.api.getFollowers('steemgigs', username, 'blog', 1, function(err, result) {
+      let follower = Array.isArray(result) && result.length > 0 && result[0].follower == username;
+      this.$store.commit('setFollower', follower)
+    }.bind(this))
   },
   beforeDestroy () {
     this.$eventBus.$off('profile-fetched')
@@ -332,10 +350,5 @@ export default {
         background-color: #ecf5ff;
       }
     }
-  }
-
-  .follow-icon {
-    float: right;
-    font-size: 18px;
   }
 </style>

--- a/src/components/layout/nav.vue
+++ b/src/components/layout/nav.vue
@@ -173,7 +173,9 @@ export default {
     followSteemgigs () {
       sc2.setAccessToken(this.$store.state.accessToken)
       sc2.follow(this.$store.state.username, 'steemgigs', function (err, res) {
-        this.$store.commit('setFollower', true)
+        if (res != null) {
+          this.$store.commit('setFollower', true)
+        }
       }.bind(this))
     }
   },

--- a/src/components/layout/nav.vue
+++ b/src/components/layout/nav.vue
@@ -84,6 +84,9 @@
                   <router-link class="waves-effect" :to="'/@' + $store.state.username"> {{ $store.state.username + ' (' + repp + ') ' }} </router-link>
                 </el-dropdown-item>
                 <el-dropdown-item>
+                  <a class="waves-effect" @click.prevent="follow()">Follow SteemGigs <i class="icon ion-star follow-icon"></i><!-- star-outline icon when off --></a>
+                </el-dropdown-item>
+                <el-dropdown-item>
                   <router-link class="waves-effect" to="/bropro">BroPro</router-link>
                 </el-dropdown-item>
                 <el-dropdown-item>
@@ -329,5 +332,10 @@ export default {
         background-color: #ecf5ff;
       }
     }
+  }
+
+  .follow-icon {
+    float: right;
+    font-size: 18px;
   }
 </style>

--- a/src/components/layout/nav.vue
+++ b/src/components/layout/nav.vue
@@ -174,6 +174,17 @@ export default {
       sc2.follow(this.$store.state.username, 'steemgigs', function (err, res) {
         if (res != null) {
           this.$store.commit('setFollower', true)
+          this.$notify({
+            title: 'Success',
+            message: 'Following Steemgigs',
+            type: 'success'
+          })
+        } else if (err != null) {
+          this.$notify({
+            title: 'Error',
+            message: 'An error has occurred, try later',
+            type: 'error'
+          })
         }
       }.bind(this))
     }

--- a/src/components/layout/nav.vue
+++ b/src/components/layout/nav.vue
@@ -131,7 +131,6 @@ import M from 'materialize-css'
 import modal from '@/mixins/modal.js'
 import search from '@/mixins/search.js'
 import sc2 from '@/services/sc2'
-import steem from 'steem';
 
 export default {
   mixins: [modal, search],
@@ -188,13 +187,6 @@ export default {
     M.Modal.init(elem, {
       dismissible: true
     })
-
-    const username = this.$store.state.username;
-    steem.api.setOptions({ url: 'https://api.steemit.com'});
-    steem.api.getFollowers('steemgigs', username, 'blog', 1, function(err, result) {
-      let follower = Array.isArray(result) && result.length > 0 && result[0].follower == username;
-      this.$store.commit('setFollower', follower)
-    }.bind(this))
   },
   beforeDestroy () {
     this.$eventBus.$off('profile-fetched')

--- a/src/components/views/home.vue
+++ b/src/components/views/home.vue
@@ -37,6 +37,7 @@ import { Carousel, Slide } from 'vue-carousel'
 import {Plane} from 'vue-loading-spinner'
 import CatNav from '@/components/layout/catNav'
 import CategoryPreview from '@/components/snippets/category-preview'
+import SteemApi from '@/services/steem-api'
 
 export default {
   components: {
@@ -64,9 +65,22 @@ export default {
       }
     }
   },
+  mounted() {
+    this.setFollowerState();
+  },
   methods: {
     getTags (entries) {
       this.userTags = entries
+    },
+    setFollowerState () {
+      const username = this.$store.state.username
+      SteemApi.isFollower(username)
+        .then((res) => {
+          this.$store.commit('setFollower', res)
+        })
+        .catch((err) => {
+          console.log(err)
+        })
     }
   }
 }

--- a/src/plugins/mixins.js
+++ b/src/plugins/mixins.js
@@ -1,5 +1,3 @@
-import sc2 from '@/services/sc2'
-
 export default {
   methods: {
     logout () {
@@ -62,12 +60,6 @@ export default {
     monthFromArray (index) {
       let months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
       return months[index]
-    },
-    follow () {
-      sc2.setAccessToken(this.$store.state.accessToken)
-      sc2.follow(this.$store.state.username, 'steemgigs', function (err, res) {
-        console.log(err, res)
-      })
     }
   }
 }

--- a/src/plugins/mixins.js
+++ b/src/plugins/mixins.js
@@ -1,3 +1,5 @@
+import sc2 from '@/services/sc2'
+
 export default {
   methods: {
     logout () {
@@ -60,6 +62,12 @@ export default {
     monthFromArray (index) {
       let months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
       return months[index]
+    },
+    follow () {
+      sc2.setAccessToken(this.$store.state.accessToken)
+      sc2.follow(this.$store.state.username, 'steemgigs', function (err, res) {
+        console.log(err, res)
+      })
     }
   }
 }

--- a/src/services/steem-api.js
+++ b/src/services/steem-api.js
@@ -1,0 +1,19 @@
+import steem from 'steem'
+
+steem.api.setOptions({
+  url: 'https://api.steemit.com'
+})
+
+export default {
+  isFollower (username) {
+    return new Promise((resolve, reject) => {
+      steem.api.getFollowers('steemgigs', username, 'blog', 1, (err, result) => {
+        if (err == null) {
+          resolve(Array.isArray(result) && result.length > 0 && result[0].follower === username)
+        } else {
+          reject(err)
+        }
+      })
+    })
+  }
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,7 +21,8 @@ export default new Vuex.Store({
       name: '',
       profileImage: 'https://via.placeholder.com/100x100',
       rep: '',
-      steemgigsWitness: ''
+      steemgigsWitness: '',
+      follower: false
     },
     posts: {
       steemgigs: [],
@@ -200,6 +201,9 @@ export default new Vuex.Store({
     },
     setSearchTerm (state, term) {
       state.searchTerm = term
+    },
+    setFollower (state, follower) {
+      state.profile.follower = follower
     }
   },
   getters: {


### PR DESCRIPTION
### I have followed these steps to develop this task ( #64 ).

1. Property `follower` created in store state, this property is inside `profile` property.
```
...,
profile: {
  ...,
  follower: false
}
```
2. Commit to modify property called `setFollower` created.
3. Service for steem api created to validate `follower` state.
4. Method created inside home component to get steem api service to validate `follower` state. This method was created here, because application init here after login.
5. Button inside dropdown for user login created `Following Steemgigs`.
6. Method created to set following in the state and steem with steemconnect.
7. Notification showed for steemconnect follow method state, it can be success or show an error if request fail.

### Result:

![steemgigs-tak64](https://user-images.githubusercontent.com/35630941/57989329-d58fdb00-7a5e-11e9-9599-60ee4a25400c.gif)
